### PR TITLE
fix not to match a multiwords keyword in a string literal or a comment

### DIFF
--- a/lib/anbt-sql-formatter/parser.rb
+++ b/lib/anbt-sql-formatter/parser.rb
@@ -259,7 +259,7 @@ class AnbtSql
             x.string.sub(/\s+/, " ")
           }
 
-          if /#{kw.join(" ")}/i =~ temp_tokens.join
+          if equals_ignore_case(kw.join(" "), temp_tokens.join)
             tokens[index].string = temp_tokens.join
             (target_tokens_size-1).downto(1).each{|c|
               tokens.delete_at(index + c)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -455,5 +455,39 @@ class TestAnbtSqlParser < Test::Unit::TestCase
       )))
     )
 
+    ########
+    assert_equals(
+      msg + "multiwords keyword 3",
+      strip_indent(
+        <<-EOB
+        keyword (select)
+        space ( )
+        value ('group by')
+        EOB
+      ),
+      _format( @parser.parse(strip_indent(
+        <<-EOB
+        select 'group by'
+        EOB
+      )))
+    )
+
+    ########
+    assert_equals(
+      msg + "multiwords keyword 4",
+      strip_indent(
+        <<-EOB
+        keyword (select)
+        space ( )
+        comment (/*group by*/)
+        EOB
+      ),
+      _format( @parser.parse(strip_indent(
+        <<-EOB
+        select /*group by*/
+        EOB
+      )))
+    )
+
   end
 end


### PR DESCRIPTION
Issue #4