### PR TITLE
enable compact in values

### DIFF
--- a/lib/anbt-sql-formatter/in_values_checker.rb
+++ b/lib/anbt-sql-formatter/in_values_checker.rb
@@ -1,0 +1,32 @@
+class AnbtSql
+  class InValuesChecker
+    def initialize(rule)
+      if rule.in_values_num.nil?
+        @mode = :default
+      elsif rule.in_values_num == AnbtSql::Rule::ONELINE_IN_VALUES_NUM
+        @mode = :oneline
+        @num = rule.in_values_num
+      else
+        @mode = :compact
+        @num = rule.in_values_num
+        @counter = 0
+      end
+    end
+
+    def check
+      if @mode == :default
+        true
+      elsif @mode == :oneline
+        false
+      else
+        @counter += 1
+        if @counter == @num
+          @counter = 0
+          true
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/anbt-sql-formatter/rule.rb
+++ b/lib/anbt-sql-formatter/rule.rb
@@ -32,15 +32,19 @@ class AnbtSql
     attr_accessor :kw_nl_x
     attr_accessor :kw_nl_x_plus1_indent
 
+    attr_accessor :in_values_num
+
     # キーワードの変換規則: 何もしない
     KEYWORD_NONE = 0
 
     # キーワードの変換規則: 大文字にする
     KEYWORD_UPPER_CASE = 1
-    
+
     # キーワードの変換規則: 小文字にする
     KEYWORD_LOWER_CASE = 2
 
+    # IN の値を一行表示する場合の in_values_num 値
+    ONELINE_IN_VALUES_NUM = 0
 
     def initialize
       # キーワードの変換規則.
@@ -51,7 +55,7 @@ class AnbtSql
       @indent_string = "    "
 
       @space_after_comma = false
-      
+
       # __foo
       # ____KW
       @kw_plus1_indent_x_nl = %w(INSERT INTO CREATE DROP TRUNCATE TABLE CASE)
@@ -65,12 +69,12 @@ class AnbtSql
       # __foo
       # ____KW
       @kw_nl_x_plus1_indent = %w(ON USING)
-      
+
       # __foo
       # __KW
       @kw_nl_x = %w(OR THEN ELSE)
       # @kw_nl_x = %w(OR WHEN ELSE)
-      
+
       @kw_multi_words = ["ORDER BY", "GROUP BY"]
 
       # 関数の名前。
@@ -117,7 +121,7 @@ class AnbtSql
           return true
         end
       end
-      
+
       return false
     end
   end

--- a/test/test_in_values.rb
+++ b/test/test_in_values.rb
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "helper")
+
+require "anbt-sql-formatter/formatter"
+
+class TestAnbtSqlInValues < Test::Unit::TestCase
+  def test_format_without_in_values_num
+    rule = base_rule
+    @fmt = AnbtSql::Formatter.new(rule)
+    msg = "without in_values_num setting"
+    sql = "select * from users where id in (" + (1...30).to_a.join(",") + ")"
+    expected = <<EOS
+SELECT
+    *
+  FROM
+    users
+  WHERE
+    id IN (
+      1
+      ,2
+      ,3
+      ,4
+      ,5
+      ,6
+      ,7
+      ,8
+      ,9
+      ,10
+      ,11
+      ,12
+      ,13
+      ,14
+      ,15
+      ,16
+      ,17
+      ,18
+      ,19
+      ,20
+      ,21
+      ,22
+      ,23
+      ,24
+      ,25
+      ,26
+      ,27
+      ,28
+      ,29
+    )
+EOS
+
+     assert_equals(msg, expected.strip, @fmt.format(sql))
+  end
+
+  def test_format_num_in_values
+    rule = base_rule
+    rule.in_values_num = 10
+    @fmt = AnbtSql::Formatter.new(rule)
+    msg = "num in values"
+    sql = "select * from users where id in (" + (1...100).to_a.join(",") + ")"
+    expected = <<EOS
+SELECT
+    *
+  FROM
+    users
+  WHERE
+    id IN (
+      1 ,2 ,3 ,4 ,5 ,6 ,7 ,8 ,9 ,10
+      ,11 ,12 ,13 ,14 ,15 ,16 ,17 ,18 ,19 ,20
+      ,21 ,22 ,23 ,24 ,25 ,26 ,27 ,28 ,29 ,30
+      ,31 ,32 ,33 ,34 ,35 ,36 ,37 ,38 ,39 ,40
+      ,41 ,42 ,43 ,44 ,45 ,46 ,47 ,48 ,49 ,50
+      ,51 ,52 ,53 ,54 ,55 ,56 ,57 ,58 ,59 ,60
+      ,61 ,62 ,63 ,64 ,65 ,66 ,67 ,68 ,69 ,70
+      ,71 ,72 ,73 ,74 ,75 ,76 ,77 ,78 ,79 ,80
+      ,81 ,82 ,83 ,84 ,85 ,86 ,87 ,88 ,89 ,90
+      ,91 ,92 ,93 ,94 ,95 ,96 ,97 ,98 ,99
+    )
+EOS
+
+     assert_equals(msg, expected.strip, @fmt.format(sql))
+  end
+
+  def test_format_str_in_values
+    rule = base_rule
+    rule.in_values_num = 10
+    @fmt = AnbtSql::Formatter.new(rule)
+    msg = "str in values"
+    sql = "select * from users where id in (" + (1...100).map { |i| "'#{i}'"  }.join(",") + ")"
+    expected = <<EOS
+SELECT
+    *
+  FROM
+    users
+  WHERE
+    id IN (
+      '1' ,'2' ,'3' ,'4' ,'5' ,'6' ,'7' ,'8' ,'9' ,'10'
+      ,'11' ,'12' ,'13' ,'14' ,'15' ,'16' ,'17' ,'18' ,'19' ,'20'
+      ,'21' ,'22' ,'23' ,'24' ,'25' ,'26' ,'27' ,'28' ,'29' ,'30'
+      ,'31' ,'32' ,'33' ,'34' ,'35' ,'36' ,'37' ,'38' ,'39' ,'40'
+      ,'41' ,'42' ,'43' ,'44' ,'45' ,'46' ,'47' ,'48' ,'49' ,'50'
+      ,'51' ,'52' ,'53' ,'54' ,'55' ,'56' ,'57' ,'58' ,'59' ,'60'
+      ,'61' ,'62' ,'63' ,'64' ,'65' ,'66' ,'67' ,'68' ,'69' ,'70'
+      ,'71' ,'72' ,'73' ,'74' ,'75' ,'76' ,'77' ,'78' ,'79' ,'80'
+      ,'81' ,'82' ,'83' ,'84' ,'85' ,'86' ,'87' ,'88' ,'89' ,'90'
+      ,'91' ,'92' ,'93' ,'94' ,'95' ,'96' ,'97' ,'98' ,'99'
+    )
+EOS
+
+     assert_equals(msg, expected.strip, @fmt.format(sql))
+  end
+
+  def test_format_oneline_in_values
+    rule = base_rule
+    rule.in_values_num = AnbtSql::Rule::ONELINE_IN_VALUES_NUM
+    @fmt = AnbtSql::Formatter.new(rule)
+    msg = "oneline in values"
+    sql = "select * from users where id in (" + (1...50).to_a.join(",") + ")"
+    expected = <<EOS
+SELECT
+    *
+  FROM
+    users
+  WHERE
+    id IN (
+      1 ,2 ,3 ,4 ,5 ,6 ,7 ,8 ,9 ,10 ,11 ,12 ,13 ,14 ,15 ,16 ,17 ,18 ,19 ,20 ,21 ,22 ,23 ,24 ,25 ,26 ,27 ,28 ,29 ,30 ,31 ,32 ,33 ,34 ,35 ,36 ,37 ,38 ,39 ,40 ,41 ,42 ,43 ,44 ,45 ,46 ,47 ,48 ,49
+    )
+EOS
+
+     assert_equals(msg, expected.strip, @fmt.format(sql))
+  end
+
+  def test_format_with_space_after_comma
+    rule = base_rule
+    rule.in_values_num = 10
+    rule.space_after_comma = true
+    @fmt = AnbtSql::Formatter.new(rule)
+    msg = "num in values"
+    sql = "select * from users where id in (" + (1...100).to_a.join(",") + ")"
+    expected = <<EOS
+SELECT
+    *
+  FROM
+    users
+  WHERE
+    id IN (
+      1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 , 10
+      , 11 , 12 , 13 , 14 , 15 , 16 , 17 , 18 , 19 , 20
+      , 21 , 22 , 23 , 24 , 25 , 26 , 27 , 28 , 29 , 30
+      , 31 , 32 , 33 , 34 , 35 , 36 , 37 , 38 , 39 , 40
+      , 41 , 42 , 43 , 44 , 45 , 46 , 47 , 48 , 49 , 50
+      , 51 , 52 , 53 , 54 , 55 , 56 , 57 , 58 , 59 , 60
+      , 61 , 62 , 63 , 64 , 65 , 66 , 67 , 68 , 69 , 70
+      , 71 , 72 , 73 , 74 , 75 , 76 , 77 , 78 , 79 , 80
+      , 81 , 82 , 83 , 84 , 85 , 86 , 87 , 88 , 89 , 90
+      , 91 , 92 , 93 , 94 , 95 , 96 , 97 , 98 , 99
+    )
+EOS
+
+     assert_equals(msg, expected.strip, @fmt.format(sql))
+  end
+
+  def test_format_ignore_in_values_compact_when_select
+    rule = base_rule
+    rule.in_values_num = AnbtSql::Rule::ONELINE_IN_VALUES_NUM
+    @fmt = AnbtSql::Formatter.new(rule)
+    msg = "num in values"
+    sql = "select * from users where id in (select user_id from admins)"
+    expected = <<EOS
+SELECT
+    *
+  FROM
+    users
+  WHERE
+    id IN (
+      SELECT
+          user_id
+        FROM
+          admins
+    )
+EOS
+
+     assert_equals(msg, expected.strip, @fmt.format(sql))
+  end
+
+  private
+
+  def base_rule
+    rule = AnbtSql::Rule.new
+    rule.indent_string = "  "
+    rule
+  end
+end


### PR DESCRIPTION
Hi.

The formatter prints one value per line, but if SQL has many values in the `IN` clause, the formatted SQL will be very long.
It is now possible to set the number of values to be output per line by setting.