### PR TITLE
support "schema"."table" notation

### DIFF
--- a/lib/anbt-sql-formatter/coarse-tokenizer.rb
+++ b/lib/anbt-sql-formatter/coarse-tokenizer.rb
@@ -64,7 +64,9 @@ These are exclusive:
         ## end double quote
          
         length = $1.size
-        if /\A("")/ =~ str ## escaped double quote
+        if /\A(".")/ =~ str ## schema.table
+          shift_to_buf(3)
+        elsif /\A("")/ =~ str ## escaped double quote
           shift_to_buf(2)
         else
           shift_token(length, :quote_double, :plain, :end)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -308,6 +308,21 @@ class TestAnbtSqlParser < Test::Unit::TestCase
       msg + "minus + non-number",
       strip_indent(
         <<-EOB
+        name ("admin"."test")
+        EOB
+      ),
+      _format( @parser.parse( strip_indent(
+        <<-EOB
+        "admin"."test"
+        EOB
+      )))
+    )
+
+    ########
+    assert_equals(
+      msg + "minus + non-number",
+      strip_indent(
+        <<-EOB
         symbol (-)
         name (a)
         EOB


### PR DESCRIPTION
Some tables must be referenced by a schema name and table name.